### PR TITLE
Updating .gitignore to include .vs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 .idea
 *.iml
 .DS_Store
+.vs


### PR DESCRIPTION
Adding Visual studio directory .vs folder to .gitignore

This change does not affect any existing functionality.

This change will ensure any updates to .vs directory made by visual studio will not show up as changes in `git status` command.