### PR TITLE
added bootstrap to index.html, adjusted navigation-loader.js, and added index.css

### DIFF
--- a/src/main/webapp/css/index.css
+++ b/src/main/webapp/css/index.css
@@ -1,0 +1,106 @@
+/*
+ * Globals
+ */
+
+/* Links */
+a,
+a:focus,
+a:hover {
+  color: #fff;
+}
+
+/* Custom default button */
+.btn-secondary,
+.btn-secondary:hover,
+.btn-secondary:focus {
+  color: #333;
+  text-shadow: none; /* Prevent inheritance from `body` */
+  background-color: #fff;
+  border: .05rem solid #fff;
+}
+
+
+/*
+ * Base structure
+ */
+
+html,
+body {
+  height: 100%;
+  background-color: rgb(19, 187, 106);
+}
+
+body {
+  display: -ms-flexbox;
+  display: flex;
+  color: #fff;
+  text-shadow: 0 .05rem .1rem rgba(0, 0, 0, .5);
+  box-shadow: inset 0 0 5rem rgba(0, 0, 0, .5);
+}
+
+.cover-container {
+  max-width: 42em;
+}
+
+
+/*
+ * Header
+ */
+.masthead {
+  margin-bottom: 2rem;
+}
+
+.masthead-brand {
+  margin-bottom: 0;
+}
+
+.nav-masthead .nav-link {
+  padding: .25rem 0;
+  font-weight: 700;
+  color: rgba(255, 255, 255, .5);
+  background-color: transparent;
+  border-bottom: .25rem solid transparent;
+}
+
+.nav-masthead .nav-link:hover,
+.nav-masthead .nav-link:focus {
+  border-bottom-color: rgba(255, 255, 255, .25);
+}
+
+.nav-masthead .nav-link + .nav-link {
+  margin-left: 1rem;
+}
+
+.nav-masthead .active {
+  color: #fff;
+  border-bottom-color: #fff;
+}
+
+@media (min-width: 48em) {
+  .masthead-brand {
+    float: left;
+  }
+  .nav-masthead {
+    float: right;
+  }
+}
+
+
+/*
+ * Cover
+ */
+.cover {
+  padding: 0 1.5rem;
+}
+.cover .btn-lg {
+  padding: .75rem 1.25rem;
+  font-weight: 700;
+}
+
+
+/*
+ * Footer
+ */
+.mastfoot {
+  color: rgba(255, 255, 255, .5);
+}

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -15,24 +15,68 @@ limitations under the License.
 -->
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>CodeU 2019 Starter Project</title>
-    <link rel="stylesheet" href="/css/main.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="">
+    <meta name="generator" content="Jekyll v3.8.5">
+    <!--link rel="stylesheet" href="/bootstrap-4.3.1-dist/css/bootstrap.css"-->
+    <!-- taking this out adds a green border - link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous"-->
+    <!--link rel="stylesheet" href="/css/main.css"-->
+    <!--added lines 28-30-->
+    <!-- Bootstrap core CSS -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">    
     <script src="/js/navigation-loader.js"></script>
+    <title>CodeU 2019 Starter Project</title>
+
+    <!--added style tags and lines 52-53-->
+    <style>
+      .bd-placeholder-img {
+        font-size: 1.125rem;
+        text-anchor: middle;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+      }
+
+      @media (min-width: 768px) {
+        .bd-placeholder-img-lg {
+          font-size: 3.5rem;
+        }
+      }
+    </style>
+
+    <!-- Custom styles for this template -->
+    <link href="css/index.css" rel="stylesheet">
+
   </head>
   <body onload="addLoginOrLogoutLinkToNavigation();">
-    <nav>
-      <ul id="navigation">
-        <li><a href="/">Home</a></li>
-        <li><a href="/aboutus.html">About Our Team</a></li>
-      </ul>
-    </nav>
-    <h1>CodeU Starter Project</h1>
-    <p>This is the CodeU starter project. Click the links above to login and visit your page.
-    You can post messages on your page, and you can visit other user pages if you have
-    their URL.</p>
-    <p>Team 24 is the best team of Google CodeU Summer 2019!</p>
+    <body class="text-center"></body>
+    <div class="cover-container d-flex w-100 h-100 p-3 mx-auto flex-column">
+      <header class="masthead mb-auto">
+        <div class="inner">
+          <h3 class="masthead-brand">Team 24</h3>
+          <nav class="nav nav-masthead justify-content-center" id="navigation">
+            <a class="nav-link active" href="/">Home</a>
+            <a class="nav-link" href="/aboutus.html">About Our Team</a>
+          </nav>
+        </div>
+      </header>
+      <main role="main" class="inner cover">  
+        <!--h1>Team 24 CodeU Project</h1-->
+        <h1 class="cover-heading">Team 24 CodeU Project</h1>
+        <!--p>This is the CodeU starter project. Click the links above to login and visit your page.
+        You can post messages on your page, and you can visit other user pages if you have
+        their URL.</p-->
+        <p class="lead">This is Team 24's CodeU project. Click the link above to login.</p>
+      </main>
+      <footer class="mastfoot mt-auto"></footer>
+    </div>
   </body>
 </html>
+
+
+
+

--- a/src/main/webapp/js/navigation-loader.js
+++ b/src/main/webapp/js/navigation-loader.js
@@ -31,14 +31,14 @@ function addLoginOrLogoutLinkToNavigation() {
       })
       .then((loginStatus) => {
         if (loginStatus.isLoggedIn) {
-          navigationElement.appendChild(createListItem(createLink(
-              '/user-page.html?user=' + loginStatus.username, 'Your Page')));
+          navigationElement.appendChild(createLink(
+              '/user-page.html?user=' + loginStatus.username, 'Your Page'));
 
           navigationElement.appendChild(
-              createListItem(createLink('/logout', 'Logout')));
+              createLink('/logout', 'Logout'));
         } else {
           navigationElement.appendChild(
-              createListItem(createLink('/login', 'Login')));
+              createLink('/login', 'Login'));
         }
       });
 }
@@ -64,5 +64,6 @@ function createLink(url, text) {
   const linkElement = document.createElement('a');
   linkElement.appendChild(document.createTextNode(text));
   linkElement.href = url;
+  linkElement.classList.add("nav-link");
   return linkElement;
 }


### PR DESCRIPTION
In order to reference bootstrap's CSS for navigation, I needed to change the nav items in index.html from list items containing links to simply links belonging the proper class (as defined in the Bootstrap CSS index.css). The lines altered in navigation-loader.js (which is only used by index.html) are to ensure that when new nav items are added to the nav bar (for example, when a user logs in, the nav bar changes from "Home / About Our Team / Login" to "Home / About Our Team / Your Page / Logout") that they are added as links--not list items containing links--and assigned the correct class so that they are formatted correctly with the static nav items "Home" and "About Our Team". 

The Bootstrap example I worked off of was Cover, which you can view [here](https://getbootstrap.com/docs/4.3/examples/cover/).