### PR TITLE
Added drop down menu with travel mode options

### DIFF
--- a/src/main/webapp/aboutus.html
+++ b/src/main/webapp/aboutus.html
@@ -58,7 +58,7 @@ limitations under the License.
                       </ul>
                       <h2>Vicente Ferrara</h2>
                       <ul>
-                        <li>Worked on _______</li>
+                        <li>Worked on Google Maps implementing features and services to display routes with different travel modes on our map.</li>
                       </ul>
                       <h2>Dushyanth Chickabasapa</h2>
                       <ul>

--- a/src/main/webapp/js/map-loader.js
+++ b/src/main/webapp/js/map-loader.js
@@ -59,6 +59,9 @@ function initMap() {
 
     map.setCenter(place.geometry.location);
   });
+  document.getElementById('mode').addEventListener('change', function() {
+    calculateAndDisplayRoute();
+  });
 }
 
 function handleLocationError(browserHasGeolocation, infoWindow, pos) {
@@ -70,13 +73,14 @@ function handleLocationError(browserHasGeolocation, infoWindow, pos) {
 }
 
 function calculateAndDisplayRoute() {
+    var selectedMode = document.getElementById('mode').value;
     var start = document.getElementById('start').value;
     var end = document.getElementById('end').value;
     directionsService.route({
       origin: start,
       destination: end,
       provideRouteAlternatives: true,
-      travelMode: 'DRIVING'
+      travelMode: google.maps.TravelMode[selectedMode]
     }, function(response, status) {
       if (status === 'OK') {
         for( var i=0, len = response.routes.length; i<len; i++){

--- a/src/main/webapp/map.html
+++ b/src/main/webapp/map.html
@@ -28,7 +28,14 @@
       <input class="form-control" id="start" type="text" placeholder="Search...">
       <label for="start">End: </label>
       <input class="form-control" id="end" type="text" placeholder="Search...">
-      <input type="submit" value="Calculate Route" onclick="calculateAndDisplayRoute()" />
+      <!--<input type="submit" value="Calculate Route" onclick="calculateAndDisplayRoute()" /> -->
+      <b>Mode of Travel: </b>
+      <select id="mode">
+        <option value="DRIVING">Driving</option>
+        <option value="WALKING">Walking</option>
+        <option value="BICYCLING">Bicycling</option>
+        <option value="TRANSIT">Transit</option>
+      </select>
       <div id="right-panel"></div>
       <div id="map" style="height:45vw;"></div>
     </main>


### PR DESCRIPTION
1. Added information to the aboutus.html 
2. Added a drop down menu with travel mode options. (Edited map.html)
3. Deleted the Calculate Route button. 

Notes: 
-The logic behind displaying all possible alternative routes works fine, but when we tried to switch to another travel mode from our drop down menu, GMaps renders the new route(s), displays it on the map but also keeps the old ones. The solution to this problem is to declare a DirectionsRenderer global variable so that as soon as we render new directions, the current ones will be erased. Nevertheless, the code behind alternative routes creates a new DirectionsRenderer every time in the loop for each route. (Edited map-loader.js)  -The button was deleted because each time when we selected a new travel mode a new route was calculated and displayed automatically, so the button became useless. 