### PR TITLE
improved the collapsible boxes on map.html based on user feedback

### DIFF
--- a/src/main/webapp/css/map-page.css
+++ b/src/main/webapp/css/map-page.css
@@ -24,24 +24,24 @@ html, body {
 }
 
 /* the CSS for displaying the directions */
-#middle-panel {
+#bottom-right-panel {
     font-family: 'Roboto','sans-serif';
     line-height: 30px;
     padding-left: 10px;
 }
 
-#middle-panel select, #middle-panel input {
+#bottom-right-panel select, #bottom-right-panel input {
     font-size: 15px;
 }
 
-#middle-panel select {
+#bottom-right-panel select {
     width: 100%;
 }
 
-#middle-panel i {
+#bottom-right-panel i {
     font-size: 12px;
 }
-#middle-panel {
+#bottom-right-panel {
 height: 100%;
 float: right;
 width: 390px;
@@ -49,24 +49,24 @@ overflow: auto;
 }
 
 /* the CSS for displaying the panel that contains the collapsibles */
-#right-panel {
+#top-right-panel {
     font-family: 'Roboto','sans-serif';
     line-height: 30px;
     padding-left: 10px;
 }
 
-#right-panel select, #right-panel input {
+#top-right-panel select, #top-right-panel input {
     font-size: 15px;
 }
 
-#right-panel select {
+#top-right-panel select {
     width: 100%;
 }
 
-#right-panel i {
+#top-right-panel i {
     font-size: 12px;
 }
-#right-panel {
+#top-right-panel {
 height: 100%;
 float: right;
 width: 390px;

--- a/src/main/webapp/css/map-page.css
+++ b/src/main/webapp/css/map-page.css
@@ -22,6 +22,33 @@ html, body {
     line-height: 30px;
     padding-left: 10px;
 }
+
+/* the CSS for displaying the directions */
+#middle-panel {
+    font-family: 'Roboto','sans-serif';
+    line-height: 30px;
+    padding-left: 10px;
+}
+
+#middle-panel select, #middle-panel input {
+    font-size: 15px;
+}
+
+#middle-panel select {
+    width: 100%;
+}
+
+#middle-panel i {
+    font-size: 12px;
+}
+#middle-panel {
+height: 100%;
+float: right;
+width: 390px;
+overflow: auto;
+}
+
+/* the CSS for displaying the panel that contains the collapsibles */
 #right-panel {
     font-family: 'Roboto','sans-serif';
     line-height: 30px;
@@ -46,10 +73,16 @@ width: 390px;
 overflow: auto;
 }
 
+/* so the dashboard effect info is only displayed after a route has been requested 
+via clicking the calc route button */
+#dashboard-info {
+    display: none;
+    }
+
 /* Style the button that is used to open and close the collapsible content */
 .collapsible {
-    background-color: #eee;
-    color: #444;
+    background-color: #97d378;
+    color: white;
     cursor: pointer;
     padding: 18px;
     width: 100%;
@@ -57,22 +90,37 @@ overflow: auto;
     text-align: left;
     outline: none;
     font-size: 15px;
-}
+  }
   
-/* Add a background color to the button if it is clicked on (add the .active class with JS), and when you move the mouse over it (hover) */
+/* Add a background color to the button if it is clicked on (active) and when you hover */
 .active, .collapsible:hover {
-    background-color: #ccc;
-}
+    background-color: #79c753;
+  }
 
-/* Style the collapsible content. Note: hidden by default */
+/* Style the collapsible content */ 
 .content {
     padding: 0 18px;
-    display: none;
+    font-size: 15px;
+    max-height: 0;
     overflow: hidden;
-    background-color: #f1f1f1;
-    font-size: 14px; /* TOFIX: correct display */
+    transition: max-height 0.2s ease-out;
+    background-color: #e1f3d8;
 }
-
+  
+/* the next two are the "+" and "-" reactivity of the collapsible clicks */
+.collapsible:after {
+    content: '\002B';
+    color: white;
+    font-weight: bold;
+    float: right;
+    margin-left: 5px;
+}
+  
+.active:after {
+    content: "\2212";
+}
+  
+/* map styling */
 #map {
     margin-right: 400px;
 }

--- a/src/main/webapp/js/map-loader.js
+++ b/src/main/webapp/js/map-loader.js
@@ -73,9 +73,10 @@ function handleLocationError(browserHasGeolocation, infoWindow, pos) {
     infoWindow.open(map);
 }
 
-// add data on how stats would be effected by route
-function calcAndDisplayStatEffect() {
-   
+// add data on how stats would be effected by route 
+// and display after calc route button is clicked
+function calcAndDisplayStatEffect(id, visibility) {
+  document.getElementById(id).style.display = visibility;   
 }
 
 // Preload function
@@ -99,13 +100,13 @@ function calculateAndDisplayRoute() {
     }, function(response, status) {
       if (status === 'OK') {
         directionsDisplay.setDirections(response);
-        // add a call to calcAndDisplayStatEffect() here-ish
         for( var i=0, len = response.routes.length; i<len; i++){
             directionsDisplay.map = map;
             directionsDisplay.directions = response;
             directionsDisplay.routeIndex = i;
             directionsDisplay.setDirections(response);
         }
+        calcAndDisplayStatEffect("dashboard-info", "inline");
       } else {
         window.alert('Directions request failed due to ' + status);
       }
@@ -122,10 +123,10 @@ for (i = 0; i < coll.length; i++) {
   coll[i].addEventListener("click", function() {
     this.classList.toggle("active");
     var content = this.nextElementSibling;
-    if (content.style.display === "block") {
-      content.style.display = "none";
+    if (content.style.maxHeight){
+      content.style.maxHeight = null;
     } else {
-      content.style.display = "block";
-    }
+      content.style.maxHeight = content.scrollHeight + "px";
+    } 
   });
 }

--- a/src/main/webapp/map.html
+++ b/src/main/webapp/map.html
@@ -38,21 +38,20 @@
         <option value="TRANSIT">Transit</option>
       </select>
       <button onclick="calculateAndDisplayRoute()">Calculate Route</button>
-      <div id="right-panel"></div>
+      <div id="middle-panel"></div>
       <!--routes displayed-->
       <div id="right-panel">
-        <button class="collapsible">Route's Effect On Your Weekly Stats</button>
-        <div class="content">
+        <div id="dashboard-info">
+          <button class="collapsible">Route's Effect On Weekly Stats</button>
           <!--TOFIX: These stat changes need to be generated via MappingServlet.java/map-loader.js-->
-          <p>My Sustainable Miles: 34.3 -> 29.9</p>
-          <p>My Sustainable Hours: 7.5 -> 7.3</p>
-          <p>My Emissions: 7.312 -> 9.211</p>
-        </div>
-        <button class="collapsible">Current Challenges</button>
-        <div class="content">
+          <div class="content">
+            <p>My Sustainable Miles: 34.3 -> 29.9<br>My Sustainable Hours: 7.5 -> 7.3<br>My Emissions: 7.312 -> 9.211</p>
+          </div>
+          <button class="collapsible">Current Challenges</button>
           <!--TOFIX: This data needs to be generated via improvements to the Community feature-->
-          <p>Bike twice as much as you drive (single rider) this week!</p>
-          <p>Challenger: Eva Lynch</p>
+          <div class="content">
+            <p>Bike twice as much as you drive (single rider) this week!<br>Challenger: Eva Lynch</p>
+          </div>
         </div>
       </div>
       <div id="map" style="height:45vw;"></div>

--- a/src/main/webapp/map.html
+++ b/src/main/webapp/map.html
@@ -38,9 +38,9 @@
         <option value="TRANSIT">Transit</option>
       </select>
       <button onclick="calculateAndDisplayRoute()">Calculate Route</button>
-      <div id="middle-panel"></div>
+      <div id="bottom-right-panel"></div>
       <!--routes displayed-->
-      <div id="right-panel">
+      <div id="top-right-panel">
         <div id="dashboard-info">
           <button class="collapsible">Route's Effect On Weekly Stats</button>
           <!--TOFIX: These stat changes need to be generated via MappingServlet.java/map-loader.js-->


### PR DESCRIPTION
- Made it so that the collapsible info boxes only display when the "Calculate Route" button is pressed
- Added + and - icons to the collapsible boxes so that it would be more clear that they could be opened and closed 
- Changed the color of the boxes to better fit the theme of the app
- Changed the layout of the page to be less disruptive when displaying routes and the collapsible boxes. The elements will now be displayed on the right stacked on top of each other instead of the collapsible boxes having their own column between the map and the route data