### PR TITLE
made directions panel scrollable to improve cohesive design

### DIFF
--- a/src/main/webapp/css/map-page.css
+++ b/src/main/webapp/css/map-page.css
@@ -9,6 +9,7 @@
     margin: 0;
     padding: 0;
 }*/
+
 #floating-panel {
     position: absolute;
     top: 10px;
@@ -28,7 +29,7 @@
     font-family: 'Roboto','sans-serif';
     line-height: 30px;
     padding-left: 10px;
-    height: 100Q%;
+    height: 400px;
     float: right;
     width: 390px;
     overflow: auto;
@@ -46,18 +47,15 @@
     font-size: 12px;
 }
 
-#bottom-right-panel {
-height: 100%;
-float: right;
-width: 390px;
-overflow: auto;
-}
-
 /* the CSS for displaying the panel that contains the collapsibles */
 #top-right-panel {
     font-family: 'Roboto','sans-serif';
     line-height: 30px;
     padding-left: 10px;
+    height: 100%;
+    float: right;
+    width: 390px;
+    overflow: auto;
 }
 
 #top-right-panel select, #top-right-panel input {
@@ -70,12 +68,6 @@ overflow: auto;
 
 #top-right-panel i {
     font-size: 12px;
-}
-#top-right-panel {
-height: 100%;
-float: right;
-width: 390px;
-overflow: auto;
 }
 
 /* so the dashboard effect info is only displayed after a route has been requested 

--- a/src/main/webapp/js/map-loader.js
+++ b/src/main/webapp/js/map-loader.js
@@ -158,15 +158,16 @@ function renderDirectionsPolylines(response) {
     }
   }
   map.fitBounds(bounds);
-for (i = 0; i < coll.length; i++) {
-  coll[i].addEventListener("click", function() {
-    this.classList.toggle("active");
-    var content = this.nextElementSibling;
-    if (content.style.maxHeight){
-      content.style.maxHeight = null;
-    } else {
-      content.style.maxHeight = content.scrollHeight + "px";
-    } 
-  });
+  for (i = 0; i < coll.length; i++) {
+    coll[i].addEventListener("click", function() {
+      this.classList.toggle("active");
+      var content = this.nextElementSibling;
+      if (content.style.maxHeight){
+        content.style.maxHeight = null;
+      } else {
+        content.style.maxHeight = content.scrollHeight + "px";
+      } 
+    });
 
+  }
 }


### PR DESCRIPTION
This is a small update to how directions are displayed on our New Trip page, but I haven't been able to test via devserver to make sure it's all displaying correctly. 

In map-page.css, the css on the right-bottom-panel (the directions) has overflow set to auto, which would usually display a scroll bar automatically if needed but according to [w3schools](https://www.w3schools.com/cssref/pr_pos_overflow.asp) it only works when you have a hard coded area for the text to be displayed in. Because bottom-right-panel has it's height set to 100%, I think that's being read as the height being set to 100% of the contents to be displayed, which is why the directions panel is a different height with each route.

