### PR TITLE
Force units to always be metric

### DIFF
--- a/src/main/java/com/google/codeu/servlets/QueryHelper.java
+++ b/src/main/java/com/google/codeu/servlets/QueryHelper.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 
 public class QueryHelper  {
   private String apiKey;
-  private final String queryFormattedLink = "https://maps.googleapis.com/maps/api/directions/json?origin=%s&destination=%s&key=%s";
+  private final String queryFormattedLink = "https://maps.googleapis.com/maps/api/directions/json?origin=%s&destination=%s&key=%s&units=metric";
   
   public QueryHelper(String key)  {
     apiKey = key;


### PR DESCRIPTION
Force the query units to be in metric, always. Forgot to include in a previous pr