### PR TITLE
Store route servlet

### DIFF
--- a/src/main/java/com/google/codeu/servlets/EmissionsServlet.java
+++ b/src/main/java/com/google/codeu/servlets/EmissionsServlet.java
@@ -33,7 +33,10 @@ public class EmissionsServlet extends HttpServlet {
 	DatastoreHelper helper = new DatastoreHelper(this.datastore);
 	HashMap<String, Double> transpToDist = helper.userToSumDistanceTransportationMap(userEmail);
         double totalKilos = 0;
-        double totalUnsustainableKilos = transpToDist.get("DRIVING");
+        double totalUnsustainableKilos = 0;
+	if (transpToDist.containsKey("DRIVING"))	{
+		totalUnsustainableKilos = transpToDist.get("DRIVING");
+	}
 
 	for (String key : transpToDist.keySet()) totalKilos += transpToDist.get(key);
 	

--- a/src/main/java/com/google/codeu/servlets/MiniStatsServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MiniStatsServlet.java
@@ -112,7 +112,10 @@ public class MiniStatsServlet extends HttpServlet {
 
         //variables for third donut chart
         String favMode = getMostUsedTransportationMode(transpToDist);
-        double favModeMiles = transpToDist.get(favMode);
+        double favModeMiles = 0;
+	if (transpToDist.containsKey(favMode))	{
+		transpToDist.get(favMode);
+	}
 
         //FIXME: Not able to implement due to Challenges not being implemented correctly yet.
         int totalChallengesWon = 1;

--- a/src/main/java/com/google/codeu/servlets/QueryHelper.java
+++ b/src/main/java/com/google/codeu/servlets/QueryHelper.java
@@ -52,7 +52,7 @@ public class QueryHelper  {
     return content.toString();
   }
 
-  private Map<String, ?>  jsonStringToMap(String jsonString)	{
+  public Map<String, ?>  jsonStringToMap(String jsonString)	{
     Gson gson = new Gson();
     Map map = gson.fromJson(jsonString, Map.class);
     return map;

--- a/src/main/java/com/google/codeu/servlets/RouteFinderServlet.java
+++ b/src/main/java/com/google/codeu/servlets/RouteFinderServlet.java
@@ -59,7 +59,7 @@ public class RouteFinderServlet extends HttpServlet {
       response.getOutputStream().println("ERROR! One address is either null or empty.");
     }
 
-    String key = "AIzaSyDie7L-I-7ytTG6AiByhJefoF5Lp1B3YHs";
+    String key = "YOUR_API_KEY";
     QueryHelper queryHelper = new QueryHelper(key);
     Map directionsResult = queryHelper.mapApiCall(startAddress, endAddress);
     List<Route> routeList = directionsResultToRouteList(directionsResult, user);
@@ -86,11 +86,10 @@ public class RouteFinderServlet extends HttpServlet {
   private Trip stepToTrip(Map step)	{
     LatLong startLocation = locationMapToLatLong((Map) step.get("start_location"));
     LatLong endLocation = locationMapToLatLong((Map) step.get("end_location"));
-    System.out.println("Step travelmode " + step.get("travel_mode").toString());
     return new Trip(startLocation, endLocation,
 	       (String) step.get("travel_mode").toString(), 
-	       (double) ((Map) step.get("distance")).get("value"),
-	       (double) ((Map) step.get("duration")).get("value"),
+	       ((double) ((Map) step.get("distance")).get("value")) / 1000,
+	       ((double) ((Map) step.get("duration")).get("value")) / 1000,
 	       20);  // unsure about departure time right now...
   }
 

--- a/src/main/java/com/google/codeu/servlets/RouteFinderServlet.java
+++ b/src/main/java/com/google/codeu/servlets/RouteFinderServlet.java
@@ -54,17 +54,21 @@ public class RouteFinderServlet extends HttpServlet {
     String endAddress = request.getParameter("endAddress");
     String user = request.getParameter("userEmail");
 
-    if(startAddress == null || startAddress.equals("") ||
+    if (startAddress == null || startAddress.equals("") ||
        endAddress == null || endAddress.equals("")) {
       response.getOutputStream().println("ERROR! One address is either null or empty.");
     }
 
-    String key = "YOUR_API_KEY_HERE";
+    String key = "AIzaSyDie7L-I-7ytTG6AiByhJefoF5Lp1B3YHs";
     QueryHelper queryHelper = new QueryHelper(key);
-    List<Route> routeList = new ArrayList<Route>();
-    Trip someTrip;
     Map directionsResult = queryHelper.mapApiCall(startAddress, endAddress);
+    List<Route> routeList = directionsResultToRouteList(directionsResult, user);
+    response.getOutputStream().println(new Gson().toJson(routeList));
+  }
 
+  public List<Route> directionsResultToRouteList(Map<String, ?> directionsResult, String user)	{
+    Trip someTrip;
+    List<Route> routeList = new ArrayList<Route>();
     for (Map route : (ArrayList<Map>) directionsResult.get("routes"))  {
       for (Map leg : (ArrayList<Map>) route.get("legs"))  {
         ArrayList<Map> steps = (ArrayList<Map>) leg.get("steps");
@@ -76,8 +80,7 @@ public class RouteFinderServlet extends HttpServlet {
         routeList.add(new Route(tripList, user));
       }
     }
-
-    response.getOutputStream().println(new Gson().toJson(routeList));
+    return routeList;
   }
 
   private Trip stepToTrip(Map step)	{
@@ -93,7 +96,7 @@ public class RouteFinderServlet extends HttpServlet {
 
   private LatLong locationMapToLatLong(Map<String, Double> map)	{
     double latval = map.get("lat");
-    double longval = map.get("long");
+    double longval = map.get("lng");
     return new LatLong(latval, longval);
   }
 }

--- a/src/main/java/com/google/codeu/servlets/StoreRouteServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StoreRouteServlet.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.io.BufferedReader;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 import com.google.gson.Gson;
 
@@ -56,7 +57,7 @@ public class StoreRouteServlet extends HttpServlet {
 	}
 	String urlEncodedString = sb.toString();
 	URLDecoder dec = new URLDecoder();
-	String decodedString = dec.decode(urlEncodedString);
+	String decodedString = dec.decode(urlEncodedString, "utf-8");
 	String user = "UNKNOWN";
 	String directionsJson = "";
 	for (String s : decodedString.split("&"))  {

--- a/src/main/java/com/google/codeu/servlets/StoreRouteServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StoreRouteServlet.java
@@ -1,0 +1,81 @@
+package com.google.codeu.servlets;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.io.BufferedReader;
+import java.net.URLDecoder;
+
+import com.google.gson.Gson;
+
+import com.google.codeu.data.Datastore;
+import com.google.codeu.servlets.DatastoreHelper;
+import com.google.codeu.servlets.QueryHelper;
+import com.google.codeu.servlets.RouteFinderServlet;
+import com.google.codeu.data.Route;
+
+/*
+ * Provides a storage interface for the maps frontend.
+ * The user picks a route, then the frontend literally sends
+ *     exactly the json that it would have recieved from Gmaps.
+ *
+ * Example POST request would be sending data that looks like:
+ *
+ * {
+ *     directions : exactly whatever gmaps api sends you
+ *     user : the email of the user, for example "test@example.com"
+ * }
+ */
+@WebServlet("/storeroute")
+
+public class StoreRouteServlet extends HttpServlet {
+    private Datastore datastore;
+
+    @Override
+    public void init() {
+        this.datastore = new Datastore();
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+	System.out.println("StoreRouteServlet got POST request!");
+	QueryHelper helper = new QueryHelper("");
+	StringBuilder sb = new StringBuilder();
+	BufferedReader reader = request.getReader();
+	RouteFinderServlet rfinder = new RouteFinderServlet();
+	try	{
+		String line;
+		while ((line = reader.readLine()) != null) sb.append(line).append('\n');
+	} finally	{
+		reader.close();
+	}
+	String urlEncodedString = sb.toString();
+	URLDecoder dec = new URLDecoder();
+	String decodedString = dec.decode(urlEncodedString);
+	String user = "UNKNOWN";
+	String directionsJson = "";
+	for (String s : decodedString.split("&"))  {
+		String[] parts = s.split("=");
+		String key = parts[0];
+		String value = "";
+		for (int i = 1; i < parts.length; i++) value += parts[i];
+
+		if (key.equals("user"))  {
+			user = value;
+		}
+		if (key.equals("directions"))  {
+			directionsJson = value;
+		}
+	}
+	System.out.println(directionsJson);
+	Map<String, ?> directionsResult = helper.jsonStringToMap(directionsJson);
+	List<Route> routeList = rfinder.directionsResultToRouteList(directionsResult, "null");
+	this.datastore.storeRoute(routeList.get(0));  
+	// routeList should only be of size 1 in this situation
+    }
+}

--- a/src/main/java/com/google/codeu/servlets/StoreRouteServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StoreRouteServlet.java
@@ -66,7 +66,7 @@ public class StoreRouteServlet extends HttpServlet {
 		for (int i = 1; i < parts.length; i++) value += parts[i];
 
 		if (key.equals("user"))  {
-			user = value;
+			user = value.replace("\n", "");
 		}
 		if (key.equals("directions"))  {
 			directionsJson = value;
@@ -74,8 +74,8 @@ public class StoreRouteServlet extends HttpServlet {
 	}
 	System.out.println(directionsJson);
 	Map<String, ?> directionsResult = helper.jsonStringToMap(directionsJson);
-	List<Route> routeList = rfinder.directionsResultToRouteList(directionsResult, "null");
-	this.datastore.storeRoute(routeList.get(0));  
+	List<Route> routeList = rfinder.directionsResultToRouteList(directionsResult, user);
+	this.datastore.storeRoute(routeList.get(0));
 	// routeList should only be of size 1 in this situation
     }
 }


### PR DESCRIPTION
**What's different from this branch to master:**

Introduced StoreRouteServlet. This servlet allows the frontend to store routes into the datastore, with minimal extra effort on their part. They just pass me a post request with the following data:
```
{
    "directions" : "The json string which gmaps sends the frontend",
    "user" : "The user email. For example, test@example.com"
}
```
to the `storeroute` endpoint and this servlet handles the munging and storage of this route. I am using the output of a request like `https://maps.googleapis.com/maps/api/directions/json?origin=Disneyland&destination=Universal+Studios+Hollywood&key=OUR_API_KEY&units=metric` (remember to change the API key if you want to test). You must give it literally exactly the string which is returned by a call like this. 

Additionally, fixed a small bug in RouteFinderServlet. Was looking for `long` key in the HashMap, when I should have been looking for `lng`. Additionally, broke it up a bit and made some functionality public so I could reuse it in the new servlet. Similarly, broke up QueryHelper so I could use some of its functionality in the new servlet.